### PR TITLE
feat: publish binaries automatically on push to main and main-0.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,10 @@ name: Build
 
 on:
   pull_request: {}
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Upload the build artifacts to the release'
-        required: false
-        default: false
-        type: boolean
+  push:
+    branches:
+      - main
+      - main-0.6
 
 concurrency:
   group: ${{ github.ref_name }}-${{ github.event_name }}
@@ -227,7 +224,7 @@ jobs:
           Copy-Item -Path "holochain\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}${{ matrix.extraId }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |
@@ -344,7 +341,7 @@ jobs:
           Copy-Item -Path "kitsune2\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}${{ matrix.extraId }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |
@@ -434,7 +431,7 @@ jobs:
           Copy-Item -Path "lair\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Looking after the binaries build is reasonably simple, until something breaks. T
 - The `versions.json` that lists a tag for each of Holochain, Kitsune2 and Lair. It is the maintainer's responsibility
   to check that the listed tags are compatible with each other.
 - The `holochain` tag listed in `versions.json` is used to decide what Holochain release to publish binaries to.
-- The `build.yaml` that is a multipurpose build workflow. It is used to check PRs but if run manually with `publish=true`, it 
-  will also publish binaries to the `holochain` repository.
+- The `build.yaml` that is a multipurpose build workflow. It is used to check PRs and, on every push to `main`
+  or `main-0.6`, builds and publishes binaries to the `holochain` repository.
 - The `check.yaml` workflow that can be run against a Holochain release. It pulls all the binaries and tries to run 
   them on the supported platforms. It prints a report at the end to let you know whether each one ran successfully.
 
@@ -18,7 +18,8 @@ This project is branched for each Holochain release. The `main` branch is for th
 branches are for released versions. Doing a bump on any branch follows the same process:
 - Update the tags in `versions.json` to the desired versions.
 - Create a PR and check that the `build.yaml` workflow passes.
-- Merge the PR and then manually run the `build.yaml` workflow with `publish=true` to publish the binaries.
+- Merge the PR. The `build.yaml` workflow will run automatically on the resulting push to `main`
+  (or `main-0.6`) and publish the binaries.
 - Optionally, run the `check.yaml` workflow against the new release to verify the binaries.
 
 Binaries are published to the corresponding [github release at `holochain/holochain`](https://github.com/holochain/holochain/releases).


### PR DESCRIPTION
## Summary

- Replaces the manual `workflow_dispatch` + `publish=true` flag in `build.yaml` with a `push` trigger filtered to `main` and `main-0.6`.
- Publish steps now gate on `github.event_name == 'push'`, so any merged version-bump PR builds and uploads binaries to the corresponding holochain release without a maintainer click.
- Pull requests still run the build for validation; nothing publishes from a PR run.
- Updates the maintainer guide in `README.md` to match the new flow.

## Why now

The repo is no longer treated as unstable in practice; there's no reason to require a manual click between "merge bump PR" and "binaries available." Combined with the dispatch listener and reviewer-request changes, this makes the full path — upstream release → bump PR → review → merge → published binaries — work without manual workflow runs.

## Test plan

- [ ] Merging a no-op change (or the next bump PR) into `main` should trigger `build.yaml` on the push event and publish artifacts to the holochain release tagged in `versions.json`.
- [ ] Opening a PR should still run `build.yaml` end-to-end, with the upload steps skipped.

## Notes

- The publish steps use `gh release upload ... --clobber`, so reruns on the same `main` ref overwrite rather than duplicate.
- `concurrency.group` is unchanged: keyed on `ref_name` + `event_name`, so push runs don't cancel PR runs and rapid pushes to the same branch supersede earlier ones (desired).
- `workflow_dispatch` is dropped entirely. If a manual rerun is ever needed, GitHub's "Re-run failed jobs" on the most recent push run covers that.