### PR TITLE
fix: run bump tooling from main against the target branch

### DIFF
--- a/.github/workflows/auto-bump.yaml
+++ b/.github/workflows/auto-bump.yaml
@@ -37,10 +37,18 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v5
+      - name: Check out tooling from main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: tooling
+
+      - name: Check out target branch
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           token: ${{ secrets.token }}
+          path: target
 
       - name: Install taplo
         env:
@@ -57,6 +65,7 @@ jobs:
           taplo --version
 
       - name: Resolve versions
+        working-directory: target
         env:
           GH_TOKEN: ${{ secrets.token }}
           INPUT_TAG: ${{ inputs.tag }}
@@ -66,10 +75,11 @@ jobs:
           if [ "$INPUT_FORCE" = "true" ]; then
             ARGS+=(--force)
           fi
-          ./scripts/resolve-versions.sh "${ARGS[@]}" "$INPUT_TAG"
+          "$GITHUB_WORKSPACE/tooling/scripts/resolve-versions.sh" "${ARGS[@]}" "$INPUT_TAG"
 
       - name: Detect changes
         id: diff
+        working-directory: target
         run: |
           if git diff --quiet versions.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -81,6 +91,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          path: target
           token: ${{ secrets.token }}
           base: ${{ inputs.branch }}
           branch: auto/bump-${{ inputs.tag }}
@@ -95,5 +106,6 @@ jobs:
             and lair tags were resolved from the `Cargo.lock` at that release
             and verified to exist on their upstream repositories.
 
-            Review the diff in `versions.json` before merging, then run
-            `build.yaml` with `publish=true` to ship the binaries.
+            The bump tooling is maintained on `main` and was checked out from
+            there for this run; only `versions.json` on `${{ inputs.branch }}`
+            is changed.


### PR DESCRIPTION
## Problem

The previous `auto-bump.yaml` checked out the target branch and ran `scripts/resolve-versions.sh` from that checkout. That required the script to exist on every supported release branch. Older branches like `main-0.6` don't have it, so the manual run for `holochain-0.6.1-rc.8` failed at:

```
./scripts/resolve-versions.sh: No such file or directory
```

(See the failing job: https://github.com/holochain/binaries/actions/runs/25502436962/job/74838804394)

## Approach

Maintain the bump tooling and workflows on `main` only. The auto-bump job now:

1. Checks `main` out into `tooling/` (read-only, default `GITHUB_TOKEN`).
2. Checks the target branch out into `target/` (with `HRA_GITHUB_TOKEN` so the PR push later authenticates).
3. Runs `tooling/scripts/resolve-versions.sh` with `working-directory: target` so it edits `target/versions.json`.
4. Passes `path: target` to `peter-evans/create-pull-request@v7` so the resulting PR is created on the target branch's checkout.

The PR opened against `main` or `main-0.6` only changes `versions.json`. Differences in workflow files between branches stay where they are — `build.yaml` / `check.yaml` on `main-0.6` remain authoritative for that release line, which is where divergence is actually expected.

## Test plan

- [ ] After merge, run `Dispatch listener` via `workflow_dispatch` with `tag=holochain-0.6.1-rc.8` and confirm the bump PR is opened against `main-0.6` despite that branch not containing `scripts/resolve-versions.sh`.
- [ ] Re-run the same listener for an existing `holochain-0.7.*` tag and confirm the `main` flow still works.

## Notes

- Once this lands, the existing copies of these workflows / scripts on `main-0.6` (if any are added later) become advisory only; the listener always uses the `main` versions. Cleanup of any stale copies on release branches can be a separate follow-up.