### PR TITLE
feat: publish binaries automatically on push to main and main-0.6 (backport to main-0.6)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,10 @@ name: Build
 
 on:
   pull_request: {}
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Upload the build artifacts to the release'
-        required: false
-        default: false
-        type: boolean
+  push:
+    branches:
+      - main
+      - main-0.6
 
 concurrency:
   group: ${{ github.ref_name }}-${{ github.event_name }}
@@ -200,7 +197,7 @@ jobs:
           Copy-Item -Path "holochain\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}${{ matrix.extraId }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |
@@ -290,7 +287,7 @@ jobs:
           Copy-Item -Path "kitsune2\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |
@@ -380,7 +377,7 @@ jobs:
           Copy-Item -Path "lair\target\release\${{ matrix.bin }}" -Destination "deploy\${{ matrix.cargoBin }}-${{ env.RUST_TARGET }}.exe"
 
       - name: Upload artifacts to release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Looking after the binaries build is reasonably simple, until something breaks. T
 - The `versions.json` that lists a tag for each of Holochain, Kitsune2 and Lair. It is the maintainer's responsibility
   to check that the listed tags are compatible with each other.
 - The `holochain` tag listed in `versions.json` is used to decide what Holochain release to publish binaries to.
-- The `build.yaml` that is a multipurpose build workflow. It is used to check PRs but if run manually with `publish=true`, it 
-  will also publish binaries to the `holochain` repository.
+- The `build.yaml` that is a multipurpose build workflow. It is used to check PRs and, on every push to `main`
+  or `main-0.6`, builds and publishes binaries to the `holochain` repository.
 - The `check.yaml` workflow that can be run against a Holochain release. It pulls all the binaries and tries to run 
   them on the supported platforms. It prints a report at the end to let you know whether each one ran successfully.
 
@@ -18,5 +18,6 @@ This project is branched for each Holochain release. The `main` branch is for th
 branches are for released versions. Doing a bump on any branch follows the same process:
 - Update the tags in `versions.json` to the desired versions.
 - Create a PR and check that the `build.yaml` workflow passes.
-- Merge the PR and then manually run the `build.yaml` workflow with `publish=true` to publish the binaries.
+- Merge the PR. The `build.yaml` workflow will run automatically on the resulting push to `main`
+  (or `main-0.6`) and publish the binaries.
 - Optionally, run the `check.yaml` workflow against the new release to verify the binaries.


### PR DESCRIPTION
## Summary

Backport of #35 (commit `0d58611`) to `main-0.6`. Cherry-picked cleanly with no manual adjustments needed.

- `build.yaml`: drops `workflow_dispatch.inputs.publish`, adds `push` trigger filtered to `main` and `main-0.6`, gates the upload steps on `github.event_name == 'push'`.
- `README.md`: maintainer guide updated to describe the auto-publish flow.

The push trigger lists both `main` and `main-0.6`. On this branch only the `main-0.6` entry can fire, but keeping the same trigger list as `main` means the file is identical across the two branches and stays easy to keep in sync.

## Test plan

- [ ] Merging this PR will itself fire `build.yaml` on `main-0.6`. The first run after merge will publish binaries for whatever holochain tag is currently in `versions.json` on `main-0.6` — confirm the run completes and uploads to the expected release.
- [ ] Open a PR against `main-0.6` and verify it still builds for validation without publishing.