### PR TITLE
feat: publish only when versions.json changes on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - main-0.6
+    paths:
+      - versions.json
 
 concurrency:
   group: ${{ github.ref_name }}-${{ github.event_name }}


### PR DESCRIPTION
## Summary

Adds `paths: [versions.json]` to the `push` trigger of `build.yaml`. Pushes to `main` or `main-0.6` that don't change `versions.json` (e.g. workflow tweaks, README updates, script changes) no longer rebuild the binaries and overwrite the artifacts already attached to the holochain release.

Pull request validation is unchanged — every PR still runs the full build for sanity.

## Why

While iterating on workflow changes I noticed that any merge to `main` rebuilds and re-uploads with `--clobber`, replacing the binaries on the existing release with ones that the maintainer didn't intend to ship. The intended publish trigger is "we bumped versions.json"; restricting the path makes that explicit.

## Test plan

- [ ] After merge, push a workflow-only change to a feature branch and confirm `build.yaml` does not run on the resulting merge to `main` (only PR validation runs).
- [ ] Run a real bump PR and confirm the merge to `main` triggers `build.yaml` end-to-end and republishes binaries.

## Follow-up

Backport to `main-0.6` once this lands.