### PR TITLE
feat: publish only when versions.json changes on push (backport to main-0.6)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - main-0.6
+    paths:
+      - versions.json
 
 concurrency:
   group: ${{ github.ref_name }}-${{ github.event_name }}


### PR DESCRIPTION
## Summary

Backport of #38 (commit `355858c`) to `main-0.6`. Cherry-picked cleanly with no manual adjustments.

Adds `paths: [versions.json]` to the `push` trigger of `build.yaml` so workflow-only merges to `main-0.6` don't rebuild and overwrite the published binaries on the holochain release.

## Test plan

- [ ] After merge, push a workflow-only change to `main-0.6` and confirm `build.yaml` does not run on the resulting merge.
- [ ] Confirm a real bump PR merging to `main-0.6` still triggers the build and publishes binaries.