### PR TITLE
refactor: drop redundant Detect changes step in auto-bump

### DIFF
--- a/.github/workflows/auto-bump.yaml
+++ b/.github/workflows/auto-bump.yaml
@@ -77,18 +77,7 @@ jobs:
           fi
           "$GITHUB_WORKSPACE/tooling/scripts/resolve-versions.sh" "${ARGS[@]}" "$INPUT_TAG"
 
-      - name: Detect changes
-        id: diff
-        working-directory: target
-        run: |
-          if git diff --quiet versions.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create pull request
-        if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           path: target


### PR DESCRIPTION
## Summary

Removes the `Detect changes` step and the `if: steps.diff.outputs.changed == 'true'` guard on the `Create pull request` step in `auto-bump.yaml`.

`peter-evans/create-pull-request@v7` already inspects the working tree itself: if there is no diff to commit, it exits successfully without opening a PR. The local detection added nothing on top of that.

## Test plan

- [ ] Run `Dispatch listener` via `workflow_dispatch` with the currently-pinned holochain tag (no-op case) and confirm the workflow completes successfully without opening a PR.
- [ ] Run it with a tag that produces a real diff and confirm a PR is opened as before.