### PR TITLE
refactor: build holochain with default and with unstable features only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Holochain with the default backend
+          # Holochain with default features
           - os: ubuntu-22.04
             args: --package holochain
             cargoBin: holochain
@@ -42,86 +42,32 @@ jobs:
             cargoBin: holochain
             bin: holochain
 
-          # Holochain with go-pion
+          # Holochain with a subset of unstable features
           - os: ubuntu-22.04
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion --package holochain
+            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh,unstable-functions,unstable-countersigning --package holochain
             cargoBin: holochain
             bin: holochain
-            extraId: -go-pion
+            extraId: -unstable
           - os: ubuntu-22.04-arm
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion --package holochain
+            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh,unstable-functions,unstable-countersigning --package holochain
             cargoBin: holochain
             bin: holochain
-            extraId: -go-pion
+            extraId: -unstable
           - os: windows-2022
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion --package holochain
+            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh,unstable-functions,unstable-countersigning --package holochain
             cargoBin: holochain
             bin: holochain.exe
-            extraId: -go-pion
+            extraId: -unstable
           - os: macos-15-intel
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion --package holochain
+            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh,unstable-functions,unstable-countersigning --package holochain
             cargoBin: holochain
             bin: holochain
-            extraId: -go-pion
+            extraId: -unstable
           - os: macos-latest
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion --package holochain
+            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh,unstable-functions,unstable-countersigning --package holochain
             cargoBin: holochain
             bin: holochain
-            extraId: -go-pion
-
-          # Holochain with go-pion and a subset of unstable features
-          - os: ubuntu-22.04
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion,unstable-functions,unstable-countersigning --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -go-pion-unstable
-          - os: ubuntu-22.04-arm
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion,unstable-functions,unstable-countersigning --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -go-pion-unstable
-          - os: windows-2022
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion,unstable-functions,unstable-countersigning --package holochain
-            cargoBin: holochain
-            bin: holochain.exe
-            extraId: -go-pion-unstable
-          - os: macos-15-intel
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion,unstable-functions,unstable-countersigning --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -go-pion-unstable
-          - os: macos-latest
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-tx5-backend-go-pion,unstable-functions,unstable-countersigning --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -go-pion-unstable
-
-          # Holochain with iroh
-          - os: ubuntu-22.04
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -iroh
-          - os: ubuntu-22.04-arm
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -iroh
-          - os: windows-2022
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh --package holochain
-            cargoBin: holochain
-            bin: holochain.exe
-            extraId: -iroh
-          - os: macos-15-intel
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -iroh
-          - os: macos-latest
-            args: --no-default-features --features sqlite-encrypted,wasmer-sys-cranelift,transport-iroh --package holochain
-            cargoBin: holochain
-            bin: holochain
-            extraId: -iroh
+            extraId: -unstable
 
           # Holochain CLI
           - os: ubuntu-22.04

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,18 +34,10 @@ jobs:
         id: holochain
         run: |
           ./scripts/check-bin.sh ${{ inputs.check-tag }} holochain x86_64-unknown-linux-gnu
-      - name: Check Holochain go-pion
-        id: holochain-go-pion
+      - name: Check Holochain unstable
+        id: holochain-unstable
         run: |
-          ./scripts/check-bin.sh ${{ inputs.check-tag }} holochain-go-pion x86_64-unknown-linux-gnu
-      - name: Check Holochain go-pion unstable
-        id: holochain-go-pion-unstable
-        run: |
-          ./scripts/check-bin.sh ${{ inputs.check-tag }} holochain-go-pion-unstable x86_64-unknown-linux-gnu
-      - name: Check Holochain with Iroh
-        id: holochain-iroh
-        run: |
-          ./scripts/check-bin.sh ${{ inputs.check-tag }} holochain-iroh x86_64-unknown-linux-gnu
+          ./scripts/check-bin.sh ${{ inputs.check-tag }} holochain-unstable x86_64-unknown-linux-gnu
       - name: Check Holochain CLI
         id: holochain-cli
         run: |
@@ -59,9 +51,7 @@ jobs:
       kitsune2-bootstrap-srv: ${{ steps.kitsune2-bootstrap-srv.outputs.kitsune2-bootstrap-srv-result }}
       kitsune2-bootstrap-srv-iroh-relay: ${{ steps.kitsune2-bootstrap-srv-iroh-relay.outputs.kitsune2-bootstrap-srv-iroh-relay-result }}
       holochain: ${{ steps.holochain.outputs.holochain-result }}
-      holochain-go-pion: ${{ steps.holochain-go-pion.outputs.holochain-go-pion-result }}
-      holochain-go-pion-unstable: ${{ steps.holochain-go-pion-unstable.outputs.holochain-go-pion-unstable-result }}
-      holochain-iroh: ${{ steps.holochain-iroh.outputs.holochain-iroh-result }}
+      holochain-unstable: ${{ steps.holochain-unstable.outputs.holochain-unstable-result }}
       holochain-cli: ${{ steps.holochain-cli.outputs.hc-result }}
       hcterm: ${{ steps.hcterm.outputs.hcterm-result }}
 


### PR DESCRIPTION
Build Holochain with default features and with unstable features. Drop tx5 builds for Holochain.

I need the unstable Holochain build for Wind Tunnel on Holochain v0.7.0