### PR TITLE
chore: update dependabot.yml with shared content

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      background:
+      updates:
         applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
This PR updates dependeabot.yml with the content from the shared file in the hc-github-config repo.